### PR TITLE
Add installation by Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ If running `openface2_ros` results in a segfault or you see the following lines 
 
 then openface2 ros is linking against OpenCV2 instead of OpenCV3. To fix this: update cmake to at least 3.6.2, rebuild OpenCV3, clone vision\_opencv into the src folder of your catkin workspace, then recompile cv\_bridge. Remake your catkin workspace, and the segfault and warnings should have been resolved.
 
+## Installation with Docker
+
+If you don't want to change your environment, you had better to use Docker.
+
+### Requirements
+
+* Docker
+* Docker Compose
+
+### Running
+
+* xhost +local:root
+* docker-compose up
+
 ## Published Topics
 
 * `/openface2/faces` ( `openface2_ros/faces` )

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3"
+services:
+  master:
+    build: .
+    container_name: master
+    command: roscore
+
+  usb_cam:
+    build: .
+    container_name: usb_cam
+    depends_on: 
+      - master
+    devices: 
+      - /dev/video0:/dev/video0
+    environment:
+      - ROS_HOSTNAME=usb_cam
+      - ROS_MASTER_URI=http://master:11311
+    command: rosrun usb_cam usb_cam_node
+
+  openface2_ros:
+    build: .
+    container_name: openface2_ros
+    depends_on: 
+      - master
+    environment: 
+      - DISPLAY
+      - QT_X11_NO_MITSHM=1
+      - ROS_HOSTNAME=openface2_ros
+      - ROS_MASTER_URI=http://master:11311
+    volumes: 
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    command: roslaunch --wait openface2_ros openface2_ros.launch

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -44,3 +44,13 @@ RUN bash -c "cd /root/catkin_ws && source /opt/ros/melodic/setup.bash && catkin_
 
 RUN apt-get update && apt-get install -y ros-melodic-usb-cam
 
+# Load ROS environment at each run
+COPY ./ros_entrypoint.sh /
+ENTRYPOINT ["/ros_entrypoint.sh"]
+
+# Load ROS environment at exec bash
+RUN echo "source /opt/ros/melodic/setup.bash" >> /root/.bashrc
+RUN echo "source /root/catkin_ws/devel/setup.bash" >> /root/.bashrc
+
+WORKDIR /root/catkin_ws
+CMD ["bash"]

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -41,3 +41,6 @@ RUN make install
 RUN mkdir -p /root/catkin_ws/src
 RUN cd /root/catkin_ws/src && git clone https://github.com/ditoec/openface2_ros.git
 RUN bash -c "cd /root/catkin_ws && source /opt/ros/melodic/setup.bash && catkin_make"
+
+RUN apt-get update && apt-get install -y ros-melodic-usb-cam
+

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,43 @@
+FROM ros:melodic-perception
+
+RUN apt-get update && apt-get install -y \
+    libopenblas-dev \
+    unzip \
+    wget
+
+# Install OpenCV 3.4.0
+WORKDIR /root
+RUN wget https://github.com/opencv/opencv/archive/3.4.0.zip
+RUN unzip 3.4.0.zip
+RUN mkdir -p opencv-3.4.0/build
+WORKDIR /root/opencv-3.4.0/build
+RUN cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_TIFF=ON -D WITH_TBB=ON -D BUILD_SHARED_LIBS=OFF ..
+RUN make -j8
+RUN make install
+
+# Install dlib 19.13
+WORKDIR /root
+RUN wget http://dlib.net/files/dlib-19.13.tar.bz2
+RUN tar xf dlib-19.13.tar.bz2
+RUN mkdir -p dlib-19.13/build
+WORKDIR /root/dlib-19.13/build
+RUN cmake ..
+RUN cmake --build . --config Release 
+RUN make install
+
+# Install OpenFace 2.1.0
+WORKDIR /root
+RUN git clone https://github.com/TadasBaltrusaitis/OpenFace.git
+WORKDIR /root/OpenFace
+RUN git checkout OpenFace_2.1.0
+RUN bash ./download_models.sh
+RUN mkdir build
+WORKDIR /root/OpenFace/build
+RUN cmake -D CMAKE_BUILD_TYPE=RELEASE CMAKE_CXX_FLAGS="-std=c++11" -D CMAKE_EXE_LINKER_FLAGS="-std=c++11" .. 
+RUN make -j8
+RUN make install
+
+# Install openface2_ros
+RUN mkdir -p /root/catkin_ws/src
+RUN cd /root/catkin_ws/src && git clone https://github.com/ditoec/openface2_ros.git
+RUN bash -c "cd /root/catkin_ws && source /opt/ros/melodic/setup.bash && catkin_make"

--- a/docker/ros_entrypoint.sh
+++ b/docker/ros_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/melodic/setup.bash"
+source "/root/catkin_ws/devel/setup.bash"
+exec "$@"


### PR DESCRIPTION
OpenFace2 needs source installation of OpenCV and dlib but this sometimes cause version-collision to other software.
I think installation with Docker is useful for such case.

Also users can test openface2_ros easily by automated image build.